### PR TITLE
Add Kirill Müller and Nadine Hussein as contributors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,10 @@ Authors@R: c(
            comment = c(ORCID = "0000-0001-7388-1222")),
     person("Duncan", "Kennedy", , "duncan@poissonconsulting.ca", role = "ctb",
            comment = c(ORCID = "0009-0001-4880-5751")),
+    person("Kirill", "Müller", role = "ctb",
+           comment = c(ORCID = "0000-0002-1416-3412")),
+    person("Nadine", "Hussein", role = "ctb",
+           comment = c(ORCID = "0000-0003-4470-8361")),
     person("Poisson Consulting", role = c("cph", "fnd"))
   )
 Description: Manipulates date ('Date'), date time ('POSIXct') and time

--- a/man/dttr2-package.Rd
+++ b/man/dttr2-package.Rd
@@ -34,6 +34,8 @@ Authors:
 Other contributors:
 \itemize{
   \item Duncan Kennedy \email{duncan@poissonconsulting.ca} (\href{https://orcid.org/0009-0001-4880-5751}{ORCID}) [contributor]
+  \item Kirill Müller (\href{https://orcid.org/0000-0002-1416-3412}{ORCID}) [contributor]
+  \item Nadine Hussein (\href{https://orcid.org/0000-0003-4470-8361}{ORCID}) [contributor]
   \item Poisson Consulting [copyright holder, funder]
 }
 

--- a/man/dttr2-package.Rd
+++ b/man/dttr2-package.Rd
@@ -33,7 +33,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item Duncan Kennedy \email{duncan@poissonconsulting.ca} (\href{https://orcid.org/0009-0001-4880-5751}{ORCID}) [contributor]
+  \item Duncan Kennedy (\href{https://orcid.org/0009-0001-4880-5751}{ORCID}) [contributor]
   \item Kirill Müller (\href{https://orcid.org/0000-0002-1416-3412}{ORCID}) [contributor]
   \item Nadine Hussein (\href{https://orcid.org/0000-0003-4470-8361}{ORCID}) [contributor]
   \item Poisson Consulting [copyright holder, funder]


### PR DESCRIPTION
## Summary

Adds **Kirill Müller** (ORCID 0000-0002-1416-3412) and **Nadine Hussein** (ORCID 0000-0003-4470-8361) as contributors (`ctb`) in `DESCRIPTION`.

## Change

- `DESCRIPTION` — added two `person()` entries (both `"ctb"`) with ORCIDs, matching the file's `Authors@R` formatting. No other files changed.

```
person("Kirill", "Müller", role = "ctb",
       comment = c(ORCID = "0000-0002-1416-3412")),
person("Nadine", "Hussein", role = "ctb",
       comment = c(ORCID = "0000-0003-4470-8361")),
```

## Rationale

A review of the git history found both contributed but were absent from `Authors@R`:

- **Kirill Müller** — 37 commits (~9% of the 422 total), +2,922 / -750 lines (~8% of lines added).
- **Nadine Hussein** — 12 commits (~3%), +980 / -362 lines.

Both are credited as `ctb` for consistency with how contributions at this scale are handled (e.g. Duncan Kennedy is already `ctb`).

## Notes

- Contribution figures come from `git`/GitHub contributor statistics; commit and line counts are a proxy and were reviewed for substance.
- The updated `Authors@R` was verified to parse via `utils::as.person()`.
