### PR TITLE
Remove Duncan Kennedy poissonconsulting.ca email

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-7683-4592")),
     person("Ayla", "Pearson", , "ayla@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-7388-1222")),
-    person("Duncan", "Kennedy", , "duncan@poissonconsulting.ca", role = "ctb",
+    person("Duncan", "Kennedy", , role = "ctb",
            comment = c(ORCID = "0009-0001-4880-5751")),
     person("Poisson Consulting", role = c("cph", "fnd"))
   )

--- a/man/dttr2-package.Rd
+++ b/man/dttr2-package.Rd
@@ -33,7 +33,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item Duncan Kennedy \email{duncan@poissonconsulting.ca} (\href{https://orcid.org/0009-0001-4880-5751}{ORCID}) [contributor]
+  \item Duncan Kennedy (\href{https://orcid.org/0009-0001-4880-5751}{ORCID}) [contributor]
   \item Poisson Consulting [copyright holder, funder]
 }
 


### PR DESCRIPTION
Removes `duncan@poissonconsulting.ca` (no longer an active address) from DESCRIPTION; retains Duncan Kennedy as an author.