### PR TITLE
- Fix date-time parsing to preserve time component with mixed formats

### DIFF
--- a/R/date-time.R
+++ b/R/date-time.R
@@ -39,6 +39,7 @@ dtt_date_time.double <- function(x, tz = dtt_default_tz(), ...) {
 dtt_date_time.character <- function(x, tz = dtt_default_tz(), ...) {
   chk_unused(...)
   chk_string(tz)
+  x <- add_hms_date_time(x)
   dtt_floor(as.POSIXct(x, tz = tz))
 }
 

--- a/R/date-time.R
+++ b/R/date-time.R
@@ -39,8 +39,7 @@ dtt_date_time.double <- function(x, tz = dtt_default_tz(), ...) {
 dtt_date_time.character <- function(x, tz = dtt_default_tz(), ...) {
   chk_unused(...)
   chk_string(tz)
-  x <- add_hms_date_time(x)
-  dtt_floor(as.POSIXct(x, tz = tz))
+  dtt_floor(parse_date_time_character(x, tz))
 }
 
 #' @describeIn dtt_date_time Coerce Date vector to a floored POSIXct vector

--- a/R/internal.R
+++ b/R/internal.R
@@ -28,6 +28,31 @@ sub_day <- function(x, value) {
   sub("^(\\d{1,4}-\\d{1,2}-)(\\d{1,2})$", paste0("\\1", value), x)
 }
 
+# Strip trailing time-zone abbreviations (e.g. " UTC") so that a date-only
+# string can have a time component appended.
+sanitize_date_time <- function(x) {
+  sub("[^[:digit:]/:-]*$", "", x)
+}
+
+# `as.character()` drops the "00:00:00" time from midnight POSIXct values. When
+# such date-only strings are mixed with date-time strings, base R's
+# `as.POSIXct.character()` guesses a single date-only format for the whole
+# vector and discards the time component from every element (see #66). Restore a
+# uniform format by appending "00:00:00" to the date-only elements whenever the
+# vector also contains full date-times.
+add_hms_date_time <- function(x) {
+  if (!length(x)) {
+    return(x)
+  }
+
+  n0 <- !grepl(":", x) & !is.na(x)
+  n2 <- grepl(":.*:", x)
+  if (any(n0) && any(n2)) {
+    x[n0] <- paste(sanitize_date_time(x[n0]), "00:00:00")
+  }
+  x
+}
+
 #' @exportS3Method NULL
 max.hms <- function(..., na.rm = FALSE) {
   dots <- list(...)

--- a/R/internal.R
+++ b/R/internal.R
@@ -28,29 +28,43 @@ sub_day <- function(x, value) {
   sub("^(\\d{1,4}-\\d{1,2}-)(\\d{1,2})$", paste0("\\1", value), x)
 }
 
-# Strip trailing time-zone abbreviations (e.g. " UTC") so that a date-only
-# string can have a time component appended.
-sanitize_date_time <- function(x) {
-  sub("[^[:digit:]/:-]*$", "", x)
-}
+# Base R's `as.POSIXct.character()` guesses a single format for the whole vector
+# (the first of `tryFormats` that parses every element). `as.character()` drops
+# the "00:00:00" time from midnight POSIXct values, so a single date-only value
+# mixed in with date-times forces the whole vector to be parsed with a date-only
+# format, silently discarding the time component from every element (see #66).
+#
+# Parse with the date-time formats first (forcing each explicitly so date-only
+# values become NA rather than dictating the format) and only fall back to the
+# date-only formats (i.e. midnight) for the values that did not parse. The
+# formats mirror the default `tryFormats` of `as.POSIXct.character()`.
+parse_date_time_character <- function(x, tz) {
+  formats <- c(
+    "%Y-%m-%d %H:%M:%OS", "%Y/%m/%d %H:%M:%OS",
+    "%Y-%m-%d %H:%M", "%Y/%m/%d %H:%M",
+    "%Y-%m-%d", "%Y/%m/%d"
+  )
 
-# `as.character()` drops the "00:00:00" time from midnight POSIXct values. When
-# such date-only strings are mixed with date-time strings, base R's
-# `as.POSIXct.character()` guesses a single date-only format for the whole
-# vector and discards the time component from every element (see #66). Restore a
-# uniform format by appending "00:00:00" to the date-only elements whenever the
-# vector also contains full date-times.
-add_hms_date_time <- function(x) {
-  if (!length(x)) {
-    return(x)
+  out <- as.POSIXct(rep(NA_character_, length(x)), tz = tz)
+  unparsed <- !is.na(x)
+  for (format in formats) {
+    if (!any(unparsed)) {
+      break
+    }
+    i <- which(unparsed)
+    parsed <- as.POSIXct(x[i], tz = tz, format = format)
+    ok <- !is.na(parsed)
+    out[i[ok]] <- parsed[ok]
+    unparsed[i[ok]] <- FALSE
   }
 
-  n0 <- !grepl(":", x) & !is.na(x)
-  n2 <- grepl(":.*:", x)
-  if (any(n0) && any(n2)) {
-    x[n0] <- paste(sanitize_date_time(x[n0]), "00:00:00")
+  # Defer to base R for anything still unparsed so that genuinely malformed
+  # input raises the usual "not in a standard unambiguous format" error.
+  if (any(unparsed)) {
+    i <- which(unparsed)
+    out[i] <- as.POSIXct(x[i], tz = tz)
   }
-  x
+  out
 }
 
 #' @exportS3Method NULL

--- a/tests/testthat/test-date-time.R
+++ b/tests/testthat/test-date-time.R
@@ -88,6 +88,45 @@ test_that("date_time.character", {
   )
 })
 
+test_that("date_time.character handles midnight", {
+  expect_identical(
+    dtt_date_time("2025-02-02 00:00:01", tz = "UTC"),
+    as.POSIXct("2025-02-02 00:00:01", tz = "UTC")
+  )
+
+  expect_identical(
+    dtt_date_time(c("2025-02-02 00:00:01", "2025-02-02 00:00:00"), tz = "UTC"),
+    as.POSIXct(c("2025-02-02 00:00:01", "2025-02-02 00:00:00"), tz = "UTC")
+  )
+
+  expect_identical(
+    dtt_date_time(c("2025-02-02 00:00:01", "2025-02-02"), tz = "UTC"),
+    as.POSIXct(c("2025-02-02 00:00:01", "2025-02-02 00:00:00"), tz = "UTC")
+  )
+})
+
+test_that("date_time.character does not drop times for long vectors (#66)", {
+  # `as.character()` drops "00:00:00" from midnight values; a single midnight
+  # mixed in must not collapse the whole vector to dates.
+  x <- as.character(as.POSIXct(0:86400, tz = "Etc/GMT+8"))
+  expect_identical(
+    length(unique(dtt_date_time(x, tz = "Etc/GMT+8"))),
+    86401L
+  )
+
+  # The reprex from #66.
+  expect_identical(
+    dtt_date_time(
+      c("1970-01-01 23:59:58", "1970-01-01 23:59:59", "1970-01-02"),
+      tz = "Etc/GMT+1"
+    ),
+    as.POSIXct(
+      c("1970-01-01 23:59:58", "1970-01-01 23:59:59", "1970-01-02 00:00:00"),
+      tz = "Etc/GMT+1"
+    )
+  )
+})
+
 test_that("date_time.Date", {
   expect_identical(
     dtt_date_time(Sys.Date()[-1]),


### PR DESCRIPTION
Closes #66.

## Summary
Fixes an issue where `dtt_date_time()` would silently drop the time component from date-time values when a date-only value was mixed in the same vector. This occurred because base R's `as.POSIXct.character()` guesses a single format for the entire vector, and date-only values (which lack time information) would force the entire vector to be parsed with a date-only format.

## Key Changes
- **Added `parse_date_time_character()` function** in `R/internal.R` that implements a format-aware parsing strategy:
  - Attempts to parse with date-time formats first (with explicit format specification to prevent date-only values from dictating the format)
  - Falls back to date-only formats only for values that didn't parse as date-times
  - Defers to base R for genuinely malformed input to preserve standard error messages
  
- **Updated `dtt_date_time.character()`** in `R/date-time.R` to use the new parsing function instead of relying on base R's `as.POSIXct()`

- **Added comprehensive test coverage** in `tests/testthat/test-date-time.R`:
  - Tests for midnight handling with various combinations of date-time and date-only values
  - Regression test for issue #66 with long vectors containing mixed formats
  - Verification that the reprex from #66 now produces correct results

## Implementation Details
The solution mirrors the default `tryFormats` of base R's `as.POSIXct.character()` but applies them sequentially with explicit format specifications, allowing each format to be tried independently rather than guessing a single format for the entire vector. This ensures that date-only values don't inadvertently collapse the parsing format for the entire vector.

https://claude.ai/code/session_016jpx9WZ6HX5Ng8ZFuKuEaj