### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,5 @@
 ^CRAN-SUBMISSION$
 ^dev$
 ^\.ccache$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/add.R
+++ b/R/add.R
@@ -15,7 +15,8 @@ dtt_add_units <- function(x, units, n = 1L) {
   chk_string(units)
   chk_subset(units, c("seconds", "minutes", "hours", "days", "months", "years"))
 
-  switch(units,
+  switch(
+    units,
     years = dtt_add_years(x, n),
     months = dtt_add_months(x, n),
     days = dtt_add_days(x, n),

--- a/R/check.R
+++ b/R/check.R
@@ -13,10 +13,10 @@
 #'
 #' @examples
 #' check_tz(Sys.time(), "UTC", error = FALSE)
-check_tz <- function(x, tz = dtt_tz(x),
-                     x_name = substitute(x),
-                     error = TRUE) {
-  lifecycle::deprecate_soft("0.1.0", "dttr2::check_tz()",
+check_tz <- function(x, tz = dtt_tz(x), x_name = substitute(x), error = TRUE) {
+  lifecycle::deprecate_soft(
+    "0.1.0",
+    "dttr2::check_tz()",
     details = paste0(
       "Replace with `chk::chk_identical(dtt_tz(x), tz)`. To check whether a ",
       "valid time zone use `chk::chk_tz(x)`."

--- a/R/chk.R
+++ b/R/chk.R
@@ -14,7 +14,9 @@ chk_time <- function(x, x_name = NULL) {
   if (vld_time(x)) {
     return(invisible())
   }
-  if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
+  if (is.null(x_name)) {
+    x_name <- deparse_backtick_chk(substitute(x))
+  }
 
   abort_chk(x_name, " must be a time (non-missing hms::hms scalar)")
 }

--- a/R/complete.R
+++ b/R/complete.R
@@ -17,8 +17,15 @@ dtt_complete <- function(x, ...) {
 
 #' @describeIn dtt_complete Complete a Date sequence vector
 #' @export
-dtt_complete.Date <- function(x, from = min(x), to = max(x), units = "days",
-                              unique = TRUE, sort = TRUE, ...) {
+dtt_complete.Date <- function(
+  x,
+  from = min(x),
+  to = max(x),
+  units = "days",
+  unique = TRUE,
+  sort = TRUE,
+  ...
+) {
   chk_not_empty(x)
   chk_date(from)
   chk_date(to)
@@ -32,22 +39,36 @@ dtt_complete.Date <- function(x, from = min(x), to = max(x), units = "days",
   from <- dtt_floor(from, units = units)
   to <- dtt_floor(to, units = units)
 
-  if (from > to) err("from must not be greater than to")
-  if (from > min(x) || to < max(x)) err("from and to must span x")
+  if (from > to) {
+    err("from must not be greater than to")
+  }
+  if (from > min(x) || to < max(x)) {
+    err("from and to must span x")
+  }
 
   seq <- dtt_seq(from, to, units = units)
   seq <- as.Date(setdiff(as.vector(seq), as.vector(x)), origin = "1970-01-01")
-  if (unique) x <- unique(x)
+  if (unique) {
+    x <- unique(x)
+  }
   x <- c(x, seq)
-  if (sort) x <- sort(x)
+  if (sort) {
+    x <- sort(x)
+  }
   x
 }
 
 #' @describeIn dtt_complete Complete a POSIXct sequence vector
 #' @export
-dtt_complete.POSIXct <- function(x, from = min(x), to = max(x),
-                                 units = "seconds", unique = TRUE, sort = TRUE,
-                                 ...) {
+dtt_complete.POSIXct <- function(
+  x,
+  from = min(x),
+  to = max(x),
+  units = "seconds",
+  unique = TRUE,
+  sort = TRUE,
+  ...
+) {
   chk_not_empty(x)
   chk_date_time(from)
   chk_date_time(to)
@@ -64,24 +85,39 @@ dtt_complete.POSIXct <- function(x, from = min(x), to = max(x),
   from <- dtt_floor(from, units = units)
   to <- dtt_floor(to, units = units)
 
-  if (from > to) err("from must not be greater than to")
-  if (from > min(x) || to < max(x)) err("from and to must span x")
+  if (from > to) {
+    err("from must not be greater than to")
+  }
+  if (from > min(x) || to < max(x)) {
+    err("from and to must span x")
+  }
 
   seq <- try(dtt_seq(from, to, units = units), silent = FALSE)
   if (inherits(seq, "try-error")) {
     err("attempting to generate more than 2^32 POSIXct values")
   }
   seq <- as.Date(setdiff(as.vector(seq), as.vector(x)), origin = "1970-01-01")
-  if (unique) x <- unique(x)
+  if (unique) {
+    x <- unique(x)
+  }
   x <- c(x, seq)
-  if (sort) x <- sort(x)
+  if (sort) {
+    x <- sort(x)
+  }
   x
 }
 
 #' @describeIn dtt_complete Complete a hms sequence vector
 #' @export
-dtt_complete.hms <- function(x, from = min(x), to = max(x), units = "seconds",
-                             unique = TRUE, sort = TRUE, ...) {
+dtt_complete.hms <- function(
+  x,
+  from = min(x),
+  to = max(x),
+  units = "seconds",
+  unique = TRUE,
+  sort = TRUE,
+  ...
+) {
   chk_s3_class(x, "hms")
   chk_not_any_na(x)
   chk_not_empty(x)
@@ -98,16 +134,24 @@ dtt_complete.hms <- function(x, from = min(x), to = max(x), units = "seconds",
   from <- dtt_floor(from, units = units)
   to <- dtt_floor(to, units = units)
 
-  if (from > to) err("from must not be greater than to")
-  if (from > min(x) || to < max(x)) err("from and to must span x")
+  if (from > to) {
+    err("from must not be greater than to")
+  }
+  if (from > min(x) || to < max(x)) {
+    err("from and to must span x")
+  }
 
   seq <- try(dtt_seq(from, to, units = units), silent = FALSE)
   if (inherits(seq, "try-error")) {
     err("attempting to generate more than 2^32 hms values")
   }
   seq <- as.Date(setdiff(as.vector(seq), as.vector(x)), origin = "1970-01-01")
-  if (unique) x <- unique(x)
+  if (unique) {
+    x <- unique(x)
+  }
   x <- c(x, seq)
-  if (sort) x <- sort(x)
+  if (sort) {
+    x <- sort(x)
+  }
   dtt_time(x)
 }

--- a/R/completed.R
+++ b/R/completed.R
@@ -14,8 +14,13 @@ dtt_completed <- function(x, ...) {
 
 #' @describeIn dtt_completed Test if Date vector is complete
 #' @export
-dtt_completed.Date <- function(x, units = "days", unique = TRUE, sorted = TRUE,
-                               ...) {
+dtt_completed.Date <- function(
+  x,
+  units = "days",
+  unique = TRUE,
+  sorted = TRUE,
+  ...
+) {
   chk_string(units)
   chk_subset(units, c("days", "months", "years"))
   chk_flag(unique)
@@ -43,8 +48,13 @@ dtt_completed.Date <- function(x, units = "days", unique = TRUE, sorted = TRUE,
 
 #' @describeIn dtt_completed Test if POSIXct vector is complete
 #' @export
-dtt_completed.POSIXct <- function(x, units = "seconds", unique = TRUE,
-                                  sorted = TRUE, ...) {
+dtt_completed.POSIXct <- function(
+  x,
+  units = "seconds",
+  unique = TRUE,
+  sorted = TRUE,
+  ...
+) {
   chk_string(units)
   chk_subset(units, c("seconds", "minutes", "hours", "days", "months", "years"))
   chk_flag(unique)
@@ -72,8 +82,13 @@ dtt_completed.POSIXct <- function(x, units = "seconds", unique = TRUE,
 
 #' @describeIn dtt_completed Test if POSIXct vector is complete
 #' @export
-dtt_completed.hms <- function(x, units = "seconds", unique = TRUE,
-                              sorted = TRUE, ...) {
+dtt_completed.hms <- function(
+  x,
+  units = "seconds",
+  unique = TRUE,
+  sorted = TRUE,
+  ...
+) {
   chk_string(units)
   chk_subset(units, c("seconds", "minutes", "hours"))
   chk_flag(unique)

--- a/R/date-time-from-ints.R
+++ b/R/date-time-from-ints.R
@@ -50,9 +50,15 @@
 #' dtt_date_time_from_ints(year, month, day, hour, minute, second)
 #'
 #' dtt_date_time_from_ints(year, month, day)
-dtt_date_time_from_ints <- function(year = 1972L, month = 1L, day = 1L,
-                                    hour = 0L, minute = 0L, second = 0L,
-                                    tz = dtt_default_tz()) {
+dtt_date_time_from_ints <- function(
+  year = 1972L,
+  month = 1L,
+  day = 1L,
+  hour = 0L,
+  minute = 0L,
+  second = 0L,
+  tz = dtt_default_tz()
+) {
   chk::chk_whole_numeric(year)
   chk::chk_range(year, range = c(0L, 9999L))
   chk::chk_whole_numeric(month)

--- a/R/date-time.R
+++ b/R/date-time.R
@@ -51,8 +51,12 @@ dtt_date_time.character <- function(x, tz = dtt_default_tz(), ...) {
 
 #' @describeIn dtt_date_time Coerce Date vector to a floored POSIXct vector
 #' @export
-dtt_date_time.Date <- function(x, time = hms::as_hms("00:00:00"),
-                               tz = dtt_default_tz(), ...) {
+dtt_date_time.Date <- function(
+  x,
+  time = hms::as_hms("00:00:00"),
+  tz = dtt_default_tz(),
+  ...
+) {
   chk_unused(...)
   chk_string(tz)
   chk_s3_class(time, "hms")
@@ -79,8 +83,12 @@ dtt_date_time.POSIXct <- function(x, tz = dtt_tz(x), ...) {
 
 #' @describeIn dtt_date_time Coerce hms vector to a floored POSIXct vector
 #' @export
-dtt_date_time.hms <- function(x, date = dtt_date("1970-01-01"),
-                              tz = dtt_default_tz(), ...) {
+dtt_date_time.hms <- function(
+  x,
+  date = dtt_date("1970-01-01"),
+  tz = dtt_default_tz(),
+  ...
+) {
   chk_s3_class(date, "Date")
   chk_subset(length(date), c(1L, length(x)))
   chk_string(tz)

--- a/R/excel_to_date_time.R
+++ b/R/excel_to_date_time.R
@@ -18,8 +18,12 @@
 #' dtt_excel_to_date_time(c(1000.1145, 43397.84578))
 #' dtt_excel_to_date_time(45324.1234, tz = "UTC")
 #' dtt_excel_to_date_time(42370.1234, modern = FALSE)
-dtt_excel_to_date_time <- function(x, tz = dtt_default_tz(),
-                                   modern = TRUE, ...) {
+dtt_excel_to_date_time <- function(
+  x,
+  tz = dtt_default_tz(),
+  modern = TRUE,
+  ...
+) {
   chk::chk_numeric(x)
   chk::chk_string(tz)
   chk::chk_flag(modern)

--- a/R/excel_to_time.R
+++ b/R/excel_to_time.R
@@ -16,15 +16,15 @@
 dtt_excel_to_time <- function(x, ...) {
   chk::chk_numeric(x)
   chk_unused(...)
-  
+
   excel_time <- x * 24
   hour <- floor(excel_time)
-  minute <- excel_time %% 1 
+  minute <- excel_time %% 1
   minute <- minute * 60
   second <- minute %% 1
   second <- second * 60
   minute <- floor(minute)
   second <- round(second)
-  
+
   dtt_time_from_ints(hour, minute, second)
 }

--- a/R/internal.R
+++ b/R/internal.R
@@ -40,9 +40,12 @@ sub_day <- function(x, value) {
 # formats mirror the default `tryFormats` of `as.POSIXct.character()`.
 parse_date_time_character <- function(x, tz) {
   formats <- c(
-    "%Y-%m-%d %H:%M:%OS", "%Y/%m/%d %H:%M:%OS",
-    "%Y-%m-%d %H:%M", "%Y/%m/%d %H:%M",
-    "%Y-%m-%d", "%Y/%m/%d"
+    "%Y-%m-%d %H:%M:%OS",
+    "%Y/%m/%d %H:%M:%OS",
+    "%Y-%m-%d %H:%M",
+    "%Y/%m/%d %H:%M",
+    "%Y-%m-%d",
+    "%Y/%m/%d"
   )
 
   out <- as.POSIXct(rep(NA_character_, length(x)), tz = tz)

--- a/R/na.R
+++ b/R/na.R
@@ -4,7 +4,9 @@
 #' @family NA
 #' @export
 NA_POSIXct_ <- set_attr(
-  set_class(NA_real_, c("POSIXct", "POSIXt")), "tzone", "UTC"
+  set_class(NA_real_, c("POSIXct", "POSIXt")),
+  "tzone",
+  "UTC"
 )
 
 #' Missing Date
@@ -18,5 +20,6 @@ NA_Date_ <- set_class(NA_real_, "Date")
 #' A missing hms object
 #' @export
 NA_hms_ <- set_class(
-  as.difftime(NA_real_, units = "secs"), c("hms", "difftime")
+  as.difftime(NA_real_, units = "secs"),
+  c("hms", "difftime")
 )

--- a/R/season.R
+++ b/R/season.R
@@ -20,10 +20,16 @@
 #'   dates,
 #'   start = c(First = dtt_date("2000-01-01"), Second = dtt_date("2000-06-01"))
 #' )
-dtt_season <- function(x, start = c(
-                         Spring = 3L, Summer = 6L,
-                         Autumn = 9L, Winter = 12L
-                       ), first = NULL) {
+dtt_season <- function(
+  x,
+  start = c(
+    Spring = 3L,
+    Summer = 6L,
+    Autumn = 9L,
+    Winter = 12L
+  ),
+  first = NULL
+) {
   if (!vld_s3_class(x, "Date") && !vld_s3_class(x, "POSIXct")) {
     chkor_vld(vld_s3_class(x, "Date"), vld_s3_class(x, "POSIXct"))
   }
@@ -32,7 +38,9 @@ dtt_season <- function(x, start = c(
     chkor_vld(vld_whole_numeric(start), vld_s3_class(start, "Date"))
   }
 
-  if (is.numeric(start)) chk_range(start, c(1L, 12L))
+  if (is.numeric(start)) {
+    chk_range(start, c(1L, 12L))
+  }
   chk_not_any_na(start)
   chk_not_empty(start)
   chk_unique(start)
@@ -60,7 +68,9 @@ dtt_season <- function(x, start = c(
   chk_unique(start)
 
   is_length <- length(x)
-  if (!is_length) x <- as.Date("2000-01-01")
+  if (!is_length) {
+    x <- as.Date("2000-01-01")
+  }
 
   if (start[1] != dtt_date(c("1972-01-01"))) {
     first2 <- dtt_date("1972-01-01")
@@ -84,6 +94,8 @@ dtt_season <- function(x, start = c(
     }
   }
 
-  if (!is_length) x <- x[-1]
+  if (!is_length) {
+    x <- x[-1]
+  }
   x
 }

--- a/R/seq.R
+++ b/R/seq.R
@@ -17,12 +17,19 @@ dtt_seq <- function(from, to, units, length_out = NULL, ...) {
 
 #' @describeIn dtt_seq Create a Date sequence vector
 #' @export
-dtt_seq.Date <- function(from, to = from, units = "days", length_out = NULL,
-                         ...) {
+dtt_seq.Date <- function(
+  from,
+  to = from,
+  units = "days",
+  length_out = NULL,
+  ...
+) {
   chk_date(from)
   chk_string(units)
   chk_subset(units, c("days", "months", "years"))
-  if (!is.null(length_out)) chk_whole_number(length_out)
+  if (!is.null(length_out)) {
+    chk_whole_number(length_out)
+  }
   chk_unused(...)
 
   from <- dtt_floor(from, units = units)
@@ -52,18 +59,27 @@ dtt_seq.Date <- function(from, to = from, units = "days", length_out = NULL,
 
   seq <- seq(from, to, by = units2by(units))
   seq <- dtt_aggregate(seq, units = units)
-  if (!ascending) seq <- rev(seq)
+  if (!ascending) {
+    seq <- rev(seq)
+  }
   seq
 }
 
 #' @describeIn dtt_seq Create a POSIXct sequence vector
 #' @export
-dtt_seq.POSIXct <- function(from, to = from, units = "seconds",
-                            length_out = NULL, ...) {
+dtt_seq.POSIXct <- function(
+  from,
+  to = from,
+  units = "seconds",
+  length_out = NULL,
+  ...
+) {
   chk_date_time(from)
   chk_string(units)
   chk_subset(units, c("seconds", "minutes", "hours", "days", "months", "years"))
-  if (!is.null(length_out)) chk_whole_number(length_out)
+  if (!is.null(length_out)) {
+    chk_whole_number(length_out)
+  }
   chk_unused(...)
 
   from <- dtt_floor(from, units = units)
@@ -95,19 +111,29 @@ dtt_seq.POSIXct <- function(from, to = from, units = "seconds",
 
   seq <- seq(from, to, by = units2by(units), tz = tz)
   seq <- dtt_aggregate(seq, units = units)
-  if (!ascending) seq <- rev(seq)
+  if (!ascending) {
+    seq <- rev(seq)
+  }
   seq
 }
 
 
 #' @describeIn dtt_seq Create a hms sequence vector
 #' @export
-dtt_seq.hms <- function(from, to = from, units = "seconds", length_out = NULL,
-                        wrap = TRUE, ...) {
+dtt_seq.hms <- function(
+  from,
+  to = from,
+  units = "seconds",
+  length_out = NULL,
+  wrap = TRUE,
+  ...
+) {
   chk_time(from)
   chk_string(units)
   chk_subset(units, c("seconds", "minutes", "hours"))
-  if (!is.null(length_out)) chk_whole_number(length_out)
+  if (!is.null(length_out)) {
+    chk_whole_number(length_out)
+  }
   chk_flag(wrap)
   chk_unused(...)
 

--- a/R/tz.R
+++ b/R/tz.R
@@ -23,9 +23,13 @@ dtt_default_tz <- function() {
 #' @describeIn dtt_default_tz Set Default Time Zone
 #' @export
 dtt_set_default_tz <- function(tz = NULL) {
-  if (!is.null(tz)) chk_string(tz)
+  if (!is.null(tz)) {
+    chk_string(tz)
+  }
   default_tz <- options(dtt.default_tz = tz)$dtt.default_tz
-  if (is.null(default_tz)) default_tz <- Sys.timezone()
+  if (is.null(default_tz)) {
+    default_tz <- Sys.timezone()
+  }
   invisible(default_tz)
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,7 +4,9 @@
     dtt.default_tz = "UTC"
   )
   toset <- !(names(op.devtools) %in% names(op))
-  if (any(toset)) options(op.devtools[toset])
+  if (any(toset)) {
+    options(op.devtools[toset])
+  }
 
   invisible()
 }

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,6 +1,7 @@
 if (rlang::is_installed("spelling")) {
   spelling::spell_check_test(
-    vignettes = TRUE, error = FALSE,
+    vignettes = TRUE,
+    error = FALSE,
     skip_on_cran = TRUE
   )
 }

--- a/tests/testthat/test-aggregate.R
+++ b/tests/testthat/test-aggregate.R
@@ -16,7 +16,8 @@ test_that("aggregate.Date", {
   )
   expect_identical(
     dtt_aggregate(
-      as.Date(c("1992-01-01", "1991-02-02", "1991-03-03")), "years"
+      as.Date(c("1992-01-01", "1991-02-02", "1991-03-03")),
+      "years"
     ),
     as.Date(c("1992-01-01", "1991-01-01"))
   )

--- a/tests/testthat/test-base.R
+++ b/tests/testthat/test-base.R
@@ -5,6 +5,7 @@ test_that("Date", {
 test_that("c", {
   expect_identical(as.double(as.Date("1970-01-01") + 0.99), 0.99)
   expect_equal(
-    dtt_tz(c(as.POSIXct("2001-01-01 23:32:31", tz = "UTC"), NA_POSIXct_)), "UTC"
+    dtt_tz(c(as.POSIXct("2001-01-01 23:32:31", tz = "UTC"), NA_POSIXct_)),
+    "UTC"
   )
 })

--- a/tests/testthat/test-complete.R
+++ b/tests/testthat/test-complete.R
@@ -73,7 +73,6 @@ test_that("complete.POSIXct", {
     as.POSIXct(c("2001-01-01", "2001-01-02"), tz = "Etc/GMT+7")
   )
 
-
   expect_identical(
     dtt_complete(
       as.POSIXct(c("2001-01-02", "2001-01-01"), tz = "Etc/GMT+7"),

--- a/tests/testthat/test-date-add-time.R
+++ b/tests/testthat/test-date-add-time.R
@@ -20,14 +20,16 @@ test_that("date_add_time", {
   )
   expect_identical(
     dtt_date_add_time(
-      as.Date(character(0)), hms::as_hms("06:07:08"),
+      as.Date(character(0)),
+      hms::as_hms("06:07:08"),
       tz = "Etc/GMT+7"
     ),
     as.POSIXct(character(0), tz = "Etc/GMT+7")
   )
   expect_identical(
     dtt_date_add_time(
-      as.Date("2001-01-05"), hms::as_hms(NA),
+      as.Date("2001-01-05"),
+      hms::as_hms(NA),
       tz = "Etc/GMT+7"
     ),
     as.POSIXct(NA_character_, tz = "Etc/GMT+7")

--- a/tests/testthat/test-date-time-from-ints.R
+++ b/tests/testthat/test-date-time-from-ints.R
@@ -31,7 +31,9 @@ test_that("create datetime from vector of values", {
     datetimes,
     as.POSIXct(
       c(
-        "1990-01-01 00:00:00", "1991-05-10 10:25:24", "2010-08-16 14:45:47",
+        "1990-01-01 00:00:00",
+        "1991-05-10 10:25:24",
+        "2010-08-16 14:45:47",
         "2022-12-31 23:59:59"
       ),
       tz = "UTC"
@@ -61,7 +63,9 @@ test_that("create datetime from dataframe of values", {
     datetimes,
     as.POSIXct(
       c(
-        "1990-01-01 00:00:00", "1991-05-10 10:25:24", "2010-08-16 14:45:47",
+        "1990-01-01 00:00:00",
+        "1991-05-10 10:25:24",
+        "2010-08-16 14:45:47",
         "2022-12-31 23:59:59"
       ),
       tz = "UTC"
@@ -167,7 +171,8 @@ test_that("pass when lengths of vectors 1 or the same", {
     datetime,
     as.POSIXct(
       c(
-        "1990-01-01 00:00:00 UTC", "1991-06-01 00:00:00 UTC",
+        "1990-01-01 00:00:00 UTC",
+        "1991-06-01 00:00:00 UTC",
         "1992-12-01 00:00:00 UTC"
       ),
       tz = "UTC"
@@ -195,7 +200,10 @@ test_that("handles missing values by returning NA for that value", {
     datetimes,
     as.POSIXct(
       c(
-        "1990-01-01 00:00:00", NA, "2010-08-16 14:45:47", "2022-12-31 23:59:59"
+        "1990-01-01 00:00:00",
+        NA,
+        "2010-08-16 14:45:47",
+        "2022-12-31 23:59:59"
       ),
       tz = "UTC"
     )

--- a/tests/testthat/test-date-time.R
+++ b/tests/testthat/test-date-time.R
@@ -1,12 +1,14 @@
 test_that("date_time.integer", {
   expect_identical(
-    dtt_date_time(integer(0)), as.POSIXct("1970-01-01", tz = "UTC")[-1]
+    dtt_date_time(integer(0)),
+    as.POSIXct("1970-01-01", tz = "UTC")[-1]
   )
   expect_identical(dtt_date_time(NA_integer_), NA_POSIXct_)
   expect_identical(as.integer(as.POSIXct("1970-01-01", tz = "UTC")), 0L)
   expect_identical(dtt_date_time(0L), as.POSIXct("1970-01-01", tz = "UTC"))
   expect_identical(
-    dtt_date_time(-1L), as.POSIXct("1969-12-31 23:59:59", tz = "UTC")
+    dtt_date_time(-1L),
+    as.POSIXct("1969-12-31 23:59:59", tz = "UTC")
   )
   expect_identical(
     dtt_date_time(0L, tz = "Etc/GMT+8"),
@@ -14,10 +16,12 @@ test_that("date_time.integer", {
   )
 
   expect_identical(
-    dtt_date_time(2L), as.POSIXct("1970-01-01 00:00:02", tz = "UTC")
+    dtt_date_time(2L),
+    as.POSIXct("1970-01-01 00:00:02", tz = "UTC")
   )
   expect_identical(
-    dtt_date_time(-2L), as.POSIXct("1969-12-31 23:59:58", tz = "UTC")
+    dtt_date_time(-2L),
+    as.POSIXct("1969-12-31 23:59:58", tz = "UTC")
   )
 
   expect_identical(
@@ -28,7 +32,8 @@ test_that("date_time.integer", {
 
 test_that("date_time.double", {
   expect_identical(
-    dtt_date_time(double(0)), as.POSIXct("1970-01-01", tz = "UTC")[-1]
+    dtt_date_time(double(0)),
+    as.POSIXct("1970-01-01", tz = "UTC")[-1]
   )
   expect_identical(dtt_date_time(NA_real_), NA_POSIXct_)
   expect_identical(as.double(as.POSIXct("1970-01-01", tz = "UTC")), 0)

--- a/tests/testthat/test-dayte.R
+++ b/tests/testthat/test-dayte.R
@@ -14,7 +14,11 @@ test_that("dayte.Date", {
 
 test_that("dayte.Date with start and leap year", {
   more_dates <- c(
-    "1998-02-27", "1999-02-28", "2000-02-29", "2003-03-01", "2004-03-02"
+    "1998-02-27",
+    "1999-02-28",
+    "2000-02-29",
+    "2003-03-01",
+    "2004-03-02"
   )
   more_dates <- as.Date(more_dates)
 

--- a/tests/testthat/test-excel_to_time.R
+++ b/tests/testthat/test-excel_to_time.R
@@ -3,12 +3,12 @@ test_that("fraction of a day times are converted to R times", {
     dtt_excel_to_time(0.5),
     dtt_time_from_ints(12L, 0L, 0L)
   )
-  
+
   expect_equal(
     dtt_excel_to_time(0.11871527777777778),
     dtt_time_from_ints(2L, 50L, 57L)
   )
-  
+
   expect_equal(
     dtt_excel_to_time(0.9894656),
     dtt_time_from_ints(23L, 44L, 50L)
@@ -18,7 +18,11 @@ test_that("fraction of a day times are converted to R times", {
 test_that("multiple values can be passed", {
   expect_equal(
     dtt_excel_to_time(c(0.25, 0.5, 0.75)),
-    c(dtt_time_from_ints(6L, 0L, 0L), dtt_time_from_ints(12L, 0L, 0L), dtt_time_from_ints(18L, 0L, 0L))
+    c(
+      dtt_time_from_ints(6L, 0L, 0L),
+      dtt_time_from_ints(12L, 0L, 0L),
+      dtt_time_from_ints(18L, 0L, 0L)
+    )
   )
 })
 
@@ -41,7 +45,7 @@ test_that("errors with bad inputs", {
     dtt_excel_to_date_time("dates"),
     regexp = "`x` must be numeric."
   )
-  
+
   expect_error(
     dtt_excel_to_time(0.5, "hi"),
     regexp = "`...` must be unused."

--- a/tests/testthat/test-minute-decimal.R
+++ b/tests/testthat/test-minute-decimal.R
@@ -48,7 +48,8 @@ test_that("dtt_minute_decimal.hms", {
   expect_equal(dtt_minute_decimal(hms::as_hms("20:30:32")), 30.5333333333333)
   expect_equal(dtt_minute_decimal(hms::as_hms(-63)), 58.95)
   expect_identical(
-    dtt_minute_decimal(c(hms::as_hms(60), NA_hms_)), c(1, NA_real_)
+    dtt_minute_decimal(c(hms::as_hms(60), NA_hms_)),
+    c(1, NA_real_)
   )
   expect_identical(dtt_minute_decimal(hms::as_hms("24:00:00")), 0)
 })

--- a/tests/testthat/test-season.R
+++ b/tests/testthat/test-season.R
@@ -1,14 +1,26 @@
 test_that("dtt_season.Date", {
   dates <- as.Date(c(
-    "2001-01-01", "2011-05-30", "2001-02-28", "2011-03-01", "2013-06-01",
-    "2012-09-01", "2012-12-31", NA
+    "2001-01-01",
+    "2011-05-30",
+    "2001-02-28",
+    "2011-03-01",
+    "2013-06-01",
+    "2012-09-01",
+    "2012-12-31",
+    NA
   ))
 
   expect_identical(
     dtt_season(dates),
     factor(
       c(
-        "Winter", "Spring", "Winter", "Spring", "Summer", "Autumn", "Winter",
+        "Winter",
+        "Spring",
+        "Winter",
+        "Spring",
+        "Summer",
+        "Autumn",
+        "Winter",
         NA
       ),
       levels = c("Winter", "Spring", "Summer", "Autumn")
@@ -16,12 +28,19 @@ test_that("dtt_season.Date", {
   )
 
   expect_identical(
-    dtt_season(dates,
+    dtt_season(
+      dates,
       start = c(Spring = 1L, Summer = 6L, Autumn = 8L, Winter = 11L)
     ),
     factor(
       c(
-        "Spring", "Spring", "Spring", "Spring", "Summer", "Autumn", "Winter",
+        "Spring",
+        "Spring",
+        "Spring",
+        "Spring",
+        "Summer",
+        "Autumn",
+        "Winter",
         NA
       ),
       levels = c("Spring", "Summer", "Autumn", "Winter")
@@ -29,28 +48,42 @@ test_that("dtt_season.Date", {
   )
 
   expect_identical(
-    dtt_season(dates,
+    dtt_season(
+      dates,
       start = c(
-        Spring = as.Date("1972-01-01"), Summer = as.Date("1972-06-01"),
-        Autumn = as.Date("1972-08-01"), Winter = as.Date("1972-11-01")
+        Spring = as.Date("1972-01-01"),
+        Summer = as.Date("1972-06-01"),
+        Autumn = as.Date("1972-08-01"),
+        Winter = as.Date("1972-11-01")
       )
     ),
     factor(
       c(
-        "Spring", "Spring", "Spring", "Spring", "Summer", "Autumn", "Winter", NA
+        "Spring",
+        "Spring",
+        "Spring",
+        "Spring",
+        "Summer",
+        "Autumn",
+        "Winter",
+        NA
       ),
       levels = c("Spring", "Summer", "Autumn", "Winter")
     )
   )
 
   expect_identical(
-    dtt_season(dates,
-      start = c(Monsoon = 2L, `Dry Period` = 6L)
-    ),
+    dtt_season(dates, start = c(Monsoon = 2L, `Dry Period` = 6L)),
     factor(
       c(
-        "Dry Period", "Monsoon", "Monsoon", "Monsoon", "Dry Period",
-        "Dry Period", "Dry Period", NA
+        "Dry Period",
+        "Monsoon",
+        "Monsoon",
+        "Monsoon",
+        "Dry Period",
+        "Dry Period",
+        "Dry Period",
+        NA
       ),
       levels = c("Dry Period", "Monsoon")
     )
@@ -67,15 +100,27 @@ test_that("dtt_season.Date", {
 
 test_that("dtt_season.POSIXct", {
   dates <- as.POSIXct(c(
-    "2001-01-01", "2011-05-30", "2001-02-28", "2011-03-01", "2013-06-01",
-    "2012-09-01", "2012-12-31", NA
+    "2001-01-01",
+    "2011-05-30",
+    "2001-02-28",
+    "2011-03-01",
+    "2013-06-01",
+    "2012-09-01",
+    "2012-12-31",
+    NA
   ))
 
   expect_identical(
     dtt_season(dates),
     factor(
       c(
-        "Winter", "Spring", "Winter", "Spring", "Summer", "Autumn", "Winter",
+        "Winter",
+        "Spring",
+        "Winter",
+        "Spring",
+        "Summer",
+        "Autumn",
+        "Winter",
         NA
       ),
       levels = c("Winter", "Spring", "Summer", "Autumn")
@@ -83,12 +128,19 @@ test_that("dtt_season.POSIXct", {
   )
 
   expect_identical(
-    dtt_season(dates,
+    dtt_season(
+      dates,
       start = c(Spring = 1L, Summer = 6L, Autumn = 8L, Winter = 11L)
     ),
     factor(
       c(
-        "Spring", "Spring", "Spring", "Spring", "Summer", "Autumn", "Winter",
+        "Spring",
+        "Spring",
+        "Spring",
+        "Spring",
+        "Summer",
+        "Autumn",
+        "Winter",
         NA
       ),
       levels = c("Spring", "Summer", "Autumn", "Winter")
@@ -96,15 +148,24 @@ test_that("dtt_season.POSIXct", {
   )
 
   expect_identical(
-    dtt_season(dates,
+    dtt_season(
+      dates,
       start = c(
-        Spring = as.Date("1972-01-01"), Summer = as.Date("1972-06-01"),
-        Autumn = as.Date("1972-08-01"), Winter = as.Date("1972-11-01")
+        Spring = as.Date("1972-01-01"),
+        Summer = as.Date("1972-06-01"),
+        Autumn = as.Date("1972-08-01"),
+        Winter = as.Date("1972-11-01")
       )
     ),
     factor(
       c(
-        "Spring", "Spring", "Spring", "Spring", "Summer", "Autumn", "Winter",
+        "Spring",
+        "Spring",
+        "Spring",
+        "Spring",
+        "Summer",
+        "Autumn",
+        "Winter",
         NA
       ),
       levels = c("Spring", "Summer", "Autumn", "Winter")
@@ -112,13 +173,17 @@ test_that("dtt_season.POSIXct", {
   )
 
   expect_identical(
-    dtt_season(dates,
-      start = c(Monsoon = 2L, `Dry Period` = 6L)
-    ),
+    dtt_season(dates, start = c(Monsoon = 2L, `Dry Period` = 6L)),
     factor(
       c(
-        "Dry Period", "Monsoon", "Monsoon", "Monsoon", "Dry Period",
-        "Dry Period", "Dry Period", NA
+        "Dry Period",
+        "Monsoon",
+        "Monsoon",
+        "Monsoon",
+        "Dry Period",
+        "Dry Period",
+        "Dry Period",
+        NA
       ),
       levels = c("Dry Period", "Monsoon")
     )
@@ -135,7 +200,8 @@ test_that("dtt_season.POSIXct", {
 
 test_that("season order", {
   expect_identical(
-    dtt_season(as.Date(paste("2000", c(1, 4, 8, 12), "01", sep = "-")),
+    dtt_season(
+      as.Date(paste("2000", c(1, 4, 8, 12), "01", sep = "-")),
       start = c(Summer = 6L, Winter = 11L)
     ),
     structure(
@@ -146,8 +212,10 @@ test_that("season order", {
   )
 
   expect_identical(
-    dtt_season(as.Date(paste("2000", c(1, 4, 8, 12), "01", sep = "-")),
-      start = c(Summer = 6L, Winter = 11L), first = "Summer"
+    dtt_season(
+      as.Date(paste("2000", c(1, 4, 8, 12), "01", sep = "-")),
+      start = c(Summer = 6L, Winter = 11L),
+      first = "Summer"
     ),
     structure(
       c(2L, 2L, 1L, 2L),

--- a/tests/testthat/test-second.R
+++ b/tests/testthat/test-second.R
@@ -57,7 +57,8 @@ test_that("dtt_second<-.POSIXct", {
 
   x <- as.POSIXct("1970-01-01", tz = "UTC")
   expect_identical(
-    dtt_set_second(x, 30L), as.POSIXct("1970-01-01 00:00:30", tz = "UTC")
+    dtt_set_second(x, 30L),
+    as.POSIXct("1970-01-01 00:00:30", tz = "UTC")
   )
   dtt_second(x) <- 30L
   expect_identical(x, as.POSIXct("1970-01-01 00:00:30", tz = "UTC"))

--- a/tests/testthat/test-seq.R
+++ b/tests/testthat/test-seq.R
@@ -247,9 +247,7 @@ test_that("seq.POSIXct", {
 })
 
 test_that("seq.hms", {
-  expect_error(dtt_seq(NA_hms_[-1], NA_hms_[-1]),
-    class = "chk_error"
-  )
+  expect_error(dtt_seq(NA_hms_[-1], NA_hms_[-1]), class = "chk_error")
   expect_error(dtt_seq(NA_hms_, NA_hms_[-1]), class = "chk_error")
   expect_error(
     dtt_seq(hms::as_hms("00:00:00"), NA_hms_[-1]),
@@ -287,18 +285,42 @@ test_that("seq.hms", {
 
   expect_identical(
     dtt_seq(hms::as_hms("00:00:00"), length_out = 24L, units = "hours"),
-    hms::as_hms(paste0(c(
-      "00", "01", "02", "03", "04", "05",
-      "06", "07", "08", "09", 10:23
-    ), ":00:00"))
+    hms::as_hms(paste0(
+      c(
+        "00",
+        "01",
+        "02",
+        "03",
+        "04",
+        "05",
+        "06",
+        "07",
+        "08",
+        "09",
+        10:23
+      ),
+      ":00:00"
+    ))
   )
 
   expect_identical(
     dtt_seq(hms::as_hms("01:00:00"), length_out = 24L, units = "hours"),
-    hms::as_hms(paste0(c(
-      "01", "02", "03", "04", "05",
-      "06", "07", "08", "09", 10:23, "00"
-    ), ":00:00"))
+    hms::as_hms(paste0(
+      c(
+        "01",
+        "02",
+        "03",
+        "04",
+        "05",
+        "06",
+        "07",
+        "08",
+        "09",
+        10:23,
+        "00"
+      ),
+      ":00:00"
+    ))
   )
 
   expect_identical(

--- a/tests/testthat/test-wday.R
+++ b/tests/testthat/test-wday.R
@@ -5,7 +5,12 @@ test_that("wday for Dates", {
   expect_identical(
     dtt_wday(as.Date("2020-03-05") + 0:6),
     c(
-      "Thursday", "Friday", "Saturday", "Sunday", "Monday", "Tuesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+      "Sunday",
+      "Monday",
+      "Tuesday",
       "Wednesday"
     )
   )
@@ -22,7 +27,12 @@ test_that("wday for POSIXct", {
   expect_identical(
     dtt_wday(as.POSIXct("2020-03-05") + 0:6 * 86400),
     c(
-      "Thursday", "Friday", "Saturday", "Sunday", "Monday", "Tuesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+      "Sunday",
+      "Monday",
+      "Tuesday",
       "Wednesday"
     )
   )


### PR DESCRIPTION
Closes #127

Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)