### PR TITLE
Standardize CI (tier: cran)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,15 +3,16 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
 permissions:
   contents: read
 jobs:
   R-CMD-check:
-    uses: poissonconsulting/.github/.github/workflows/R-CMD-check.yml@v1
+    uses: poissonconsulting/.github/.github/workflows/R-CMD-check.yaml@v1
     with:
       tier: cran
       jags: false
+      cmdstan: false
       tex: false
       private: false
     secrets: inherit

--- a/.github/workflows/check-no-suggests.yaml
+++ b/.github/workflows/check-no-suggests.yaml
@@ -3,12 +3,12 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
 permissions:
   contents: read
 jobs:
   check-no-suggests:
-    uses: poissonconsulting/.github/.github/workflows/check-no-suggests.yml@v1
+    uses: poissonconsulting/.github/.github/workflows/check-no-suggests.yaml@v1
     with:
       private: false
     secrets: inherit

--- a/.github/workflows/fledge-bump.yaml
+++ b/.github/workflows/fledge-bump.yaml
@@ -1,6 +1,6 @@
 # Daily fledge dev-version bump. Calls the reusable engine in poissonconsulting/.github.
 # Requires the org-level secrets FLEDGE_APP_ID and FLEDGE_APP_PRIVATE_KEY (passed via
-# `secrets: inherit`) and the companion fledge-tag-on-merge.yml workflow in this repo.
+# `secrets: inherit`) and the companion fledge-tag-on-merge.yaml workflow in this repo.
 
 name: fledge-bump
 
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   fledge-bump:
-    uses: poissonconsulting/.github/.github/workflows/fledge-bump.yml@v1
+    uses: poissonconsulting/.github/.github/workflows/fledge-bump.yaml@v1
     secrets: inherit

--- a/.github/workflows/fledge-tag-on-merge.yaml
+++ b/.github/workflows/fledge-tag-on-merge.yaml
@@ -1,5 +1,5 @@
 # Tags the dev version on main after a release-path fledge-bump PR merges.
-# Required alongside fledge-bump.yml. Calls the reusable engine in poissonconsulting/.github.
+# Required alongside fledge-bump.yaml. Calls the reusable engine in poissonconsulting/.github.
 
 name: fledge-tag-on-merge
 
@@ -14,5 +14,5 @@ permissions:
 jobs:
   tag:
     if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'fledge-bump'
-    uses: poissonconsulting/.github/.github/workflows/fledge-tag-on-merge.yml@v1
+    uses: poissonconsulting/.github/.github/workflows/fledge-tag-on-merge.yaml@v1
     secrets: inherit

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
   release:
     types: [published]
   workflow_dispatch:
@@ -11,7 +11,8 @@ permissions:
   contents: write
 jobs:
   pkgdown:
-    uses: poissonconsulting/.github/.github/workflows/pkgdown.yml@v1
+    uses: poissonconsulting/.github/.github/workflows/pkgdown.yaml@v1
     with:
+      cmdstan: false
       private: false
     secrets: inherit

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -3,13 +3,14 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
 permissions:
   contents: read
 jobs:
   test-coverage:
-    uses: poissonconsulting/.github/.github/workflows/test-coverage.yml@v1
+    uses: poissonconsulting/.github/.github/workflows/test-coverage.yaml@v1
     with:
+      cmdstan: false
       tex: false
       private: false
     secrets: inherit


### PR DESCRIPTION
Closes #129.

Standardizes CI onto the reusable workflows in `poissonconsulting/.github` (tier **cran**, private=false, jags=false, cmdstan=false, tex=false). Callers: R-CMD-check, test-coverage, pkgdown, check-no-suggests; fledge callers migrated to the .yaml templates where present.